### PR TITLE
Fix sidebar collapse button

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.module.scss
+++ b/features/layout/sidebar-navigation/sidebar-navigation.module.scss
@@ -135,6 +135,10 @@
 .collapseMenuItem {
   display: none;
 
+  &.rotateArrow {
+    transform: rotate(180deg);
+  }
+
   @media (min-width: breakpoint.$desktop) {
     display: flex;
   }

--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -90,7 +90,10 @@ export function SidebarNavigation() {
               iconSrc="/icons/arrow-left.svg"
               isCollapsed={isSidebarCollapsed}
               onClick={() => toggleSidebar()}
-              className={styles.collapseMenuItem}
+              className={classNames(
+                styles.collapseMenuItem,
+                isSidebarCollapsed && styles.rotateArrow,
+              )}
             />
           </ul>
         </nav>


### PR DESCRIPTION
This PR fixes a bug causing the sidebar arrow to always point to the left regardless of the navigation state.