### PR TITLE
Fix status badges showing wrong status text and color

### DIFF
--- a/api/projects.types.ts
+++ b/api/projects.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  info = "info",
   warning = "warning",
-  critical = "critical",
+  error = "error",
 }
 
 export type Project = {

--- a/cypress/e2e/project-list.cy.ts
+++ b/cypress/e2e/project-list.cy.ts
@@ -1,4 +1,4 @@
-import capitalize from "lodash/capitalize";
+// import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
 
 describe("Project List", () => {
@@ -22,6 +22,7 @@ describe("Project List", () => {
 
     it("renders the projects", () => {
       const languageNames = ["React", "Node.js", "Python"];
+      const statusStrings = ["Critical", "Warning", "Stable"];
 
       // get all project cards
       cy.get("main")
@@ -32,10 +33,28 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el).contains(statusStrings[index]);
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");
+        });
+    });
+
+    it("renders correct status badge color", () => {
+      const statusStrings = ["Critical", "Warning", "Stable"];
+      const badgeColors = [
+        "rgb(254, 243, 242)",
+        "rgb(255, 250, 235)",
+        "rgb(236, 253, 243)",
+      ];
+
+      cy.get("main")
+        .find("li")
+        .each(($el, index) => {
+          cy.wrap($el)
+            .get("div")
+            .contains(statusStrings[index])
+            .should("have.css", "background-color", badgeColors[index]);
         });
     });
   });

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -33,7 +33,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: ProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import capitalize from "lodash/capitalize";
+// import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor } from "@features/ui";
 import { Routes } from "@config/routes";
 import { ProjectLanguage, ProjectStatus } from "@api/projects.types";
@@ -17,9 +17,15 @@ const languageNames = {
 };
 
 const statusColors = {
-  [ProjectStatus.stable]: BadgeColor.success,
+  [ProjectStatus.info]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  [ProjectStatus.error]: BadgeColor.error,
+};
+
+const statusDisplayStrings = {
+  [ProjectStatus.info]: "Stable",
+  [ProjectStatus.warning]: "Warning",
+  [ProjectStatus.error]: "Critical",
 };
 
 export function ProjectCard({ project }: ProjectCardProps) {
@@ -50,7 +56,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <div className={styles.issuesNumber}>{numEvents24h}</div>
           </div>
           <div className={styles.status}>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>
+              {statusDisplayStrings[status]}
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
This PR fixes an issue showing the incorrect status and badge color on the project cards.  The changes I made include:

- Updating the ProjectStatus enum to properly reflect the data being received from the API
- Updating the Project Card component to show the correct status and color
- Creating a Cypress test to cover the badge color and status
- Updating the Storybook example to allow for the new status name